### PR TITLE
Removed "sound" function for index; added autoplay parameter

### DIFF
--- a/pi.soundcloud.php
+++ b/pi.soundcloud.php
@@ -1,26 +1,24 @@
 <?php
 class Plugin_soundcloud extends Plugin {
 
-    var $meta = array(
-        'name'       => 'Soundcloud',
-        'version'    => '1.0',
-        'author'     => 'Jeremy Sexton',
-        'author_url' => 'http://jeremysexton.net'
-    );
-
-    public function sound()
-    {
-      $width = $this->fetchParam('width', "100%");
-      $height = $this->fetchParam('height', "166px");
-      $url = $this->fetchParam('url', null);
-    
-      if ($url) {
-	      $output = '
-	      <iframe width="'.$width.'" height="'.$height.'" src="http://w.soundcloud.com/player/?url='.$url.'&auto_play=false" frameborder="0"></iframe>
-	      ';
-	      return $output;
-      }
-      
-    }
-
+	var $meta = array(
+	'name'              => 'Soundcloud',
+	'version'           => '1.0',
+	'author'            => 'Jeremy Sexton',
+	'author_url'        => 'http://jeremysexton.net'
+	'contributor'       => 'Nick Snyder',
+	'contributor_url'   => 'http://fasterhorses.co'
+	);
+	
+	public function index() {
+		$width = $this->fetchParam('width', "100%");
+		$height = $this->fetchParam('height', "166px");
+		$url = $this->fetchParam('url', null);
+		$autoplay = $this->fetchParam('autoplay', false);
+	
+		if ($url) {
+			$output = '<iframe width="'.$width.'" height="'.$height.'" src="http://w.soundcloud.com/player/?url='.$url.'&auto_play='. $autoplay .'" frameborder="0"></iframe>';
+			return $output;
+		}
+	}
 }

--- a/readme.md
+++ b/readme.md
@@ -13,16 +13,15 @@ Feed it the url of a Soundcloud Sound and it will return an embed.
 
 ##Usage
 
-The plugin is called with {{ soundcloud:sound }}.
+The plugin is called with {{ soundcloud }}.
 
 The following parameters exist:
 
 * url (required)
-* width
-* height
-
-If width is not called, it will default to 100%, if height is not called, it will default to 166px.
+* width (default: 100%)
+* height (default: 166px)
+* autoplay (default: false)
 
 ##Example
 
-	{{ soundcloud:sound url="https://soundcloud.com/twistedpanda/do-that-trouble-i-do" width="100%" height="166px" }}
+	{{ soundcloud url="https://soundcloud.com/twistedpanda/do-that-trouble-i-do" width="100%" height="166px" autoplay="true" }}


### PR DESCRIPTION
- Removed the "sound" function and replaced it with "index". Now you can do {{ soundcloud }} rather than {{ soundcloud:sound }}
- Added a parameter for autoplay; allowing for true and false booleans
- Updated README to reflect changes
